### PR TITLE
Fix missing SQL migrations in PyPI wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ include = [
     "total_agent_memory*",
     "claude_total_memory*",
     "src*",
+    "migrations*",
 ]
 exclude = [
     "tests*",
@@ -75,6 +76,7 @@ exclude = [
 # alongside the modules. Without this they vanish in the wheel and the
 # server crashes on first migration.
 [tool.setuptools.package-data]
+migrations = ["*.sql"]
 src = [
     "**/*.sql",
     "**/*.json",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest>=8.0.0
+build>=1.2.0

--- a/src/server.py
+++ b/src/server.py
@@ -1142,7 +1142,11 @@ class Store:
 
         migrations_dir = _Path(__file__).resolve().parent.parent / "migrations"
         if not migrations_dir.is_dir():
-            return
+            raise RuntimeError(
+                f"Bundled SQL migrations are missing: {migrations_dir}. "
+                "The installation artifact is incomplete; reinstall "
+                "total-agent-memory from a distribution that includes migrations/*.sql."
+            )
 
         # Ensure tracker table
         self.db.executescript(

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -1,0 +1,33 @@
+"""Regression tests for runtime assets in built distributions."""
+
+import shutil
+from pathlib import Path
+from zipfile import ZipFile
+
+from build import ProjectBuilder
+
+
+def test_wheel_contains_all_database_migrations(tmp_path: Path) -> None:
+    """Every source migration must ship where server.py resolves it."""
+    root = Path(__file__).resolve().parents[1]
+    source = tmp_path / "source"
+    shutil.copytree(
+        root,
+        source,
+        ignore=shutil.ignore_patterns(
+            ".git", ".venv", "build", "dist", "*.egg-info", "__pycache__"
+        ),
+    )
+
+    wheel_dir = tmp_path / "wheel"
+    wheel_path = Path(ProjectBuilder(source).build("wheel", wheel_dir))
+    expected = {
+        f"migrations/{path.name}" for path in (root / "migrations").glob("*.sql")
+    }
+
+    assert expected, "the source tree must contain SQL migrations"
+    with ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+
+    assert expected <= names
+    assert "src/server.py" in names


### PR DESCRIPTION
## Problem

The PyPI 12.4.0 wheel omits every file under `migrations/`.

`src/server.py` resolves SQL migrations at the sibling path `Path(__file__).resolve().parent.parent / "migrations"`. The current setuptools configuration assigns SQL package data only to `src`, but the migration files are in the repository-root `migrations/` directory. Package data for `src` cannot include files outside that package.

A clean `pipx install total-agent-memory==12.4.0` therefore starts without applying migrations. The first `memory_save_fast` fails with:

```
table knowledge has no column named importance
```

The enrichment worker also reports:

```
no such table: enrichment_queue
```

Source and Docker installs retain the repository directory, which is why those paths do not expose the wheel defect.

## Fix

- Include `migrations*` in setuptools package discovery.
- Package `migrations/*.sql` as package data.
- Add an artifact-level test that builds from a clean copied source tree and compares the wheel's SQL files with the source migration set.
- Declare the PyPA `build` test dependency.
- Fail at startup with an actionable error if a future distribution drops the migration directory, instead of silently creating a partially migrated database.

This keeps the runtime path unchanged and avoids `data-files`, whose installation location depends on the Python installation scheme.

## Verification

- `pytest -q tests/test_wheel_contents.py`: 1 passed
- `pytest -q tests/test_importance_levels.py tests/test_deep_enrichment_queue.py`: 14 passed
- Built `total_agent_memory-12.4.0-py3-none-any.whl` in an isolated PEP 517 environment.
- Confirmed the wheel contains all 28 source SQL files.
- Installed that wheel into a clean target directory and initialized an empty `TAM_MEMORY_DIR`.
- Confirmed `knowledge.importance` and `enrichment_queue` exist after startup.

## Separate migration observation

A clean startup also logs `Migration 028 failed: duplicate column name: agent_id`. `_migrate()` adds the lineage columns before `_apply_sql_migrations()` runs `028_agent_lineage.sql`. This PR does not change migration ordering because it is separate from the missing-wheel-assets defect.

<details>
<summary>Prompt for implementing or independently checking the fix with another agent</summary>

```text
Fix the PyPI wheel packaging regression in total-agent-memory.

In release 12.4.0, migrations/*.sql is absent from the wheel. src/server.py expects migrations at Path(__file__).resolve().parent.parent / "migrations", but pyproject.toml only assigns package data to src while the SQL files live in the repository-root migrations directory.

A clean pipx installation creates an incomplete database. memory_save_fast fails with "table knowledge has no column named importance", and the enrichment worker reports "no such table: enrichment_queue". Source and Docker installations work because the repository migration directory exists.

Requirements:
1. Include every root migrations/*.sql file in both source and wheel distributions at the path expected by src/server.py.
2. Prefer setuptools package data over data-files because data-files paths vary by installation scheme.
3. Add an artifact test that builds from a clean source tree and compares the migration filenames inside the wheel with the source migration set.
4. Install the wheel against an empty memory directory and verify knowledge.importance and enrichment_queue exist.
5. Execute a real memory_save_fast against that database.
6. Replace the silent return for a missing migration directory with an actionable startup failure.
7. Do not patch individual user databases or swallow migration errors.
8. Treat the migration 028 duplicate-column failure as a separate migration-ordering issue unless the chosen test requires fixing it in the same change.
```

</details>
